### PR TITLE
change invocation path from functions to builders

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,18 +4,18 @@
 
 [[redirects]]
     from = "/hex/:color"
-    to = "/.netlify/functions/color"
+    to = "/.netlify/builders/color"
     status = 200
     force = true
 
 [[redirects]]
     from = "/rgb/:r/:g/:b"
-    to = "/.netlify/functions/color"
+    to = "/.netlify/builders/color"
     status = 200
     force = true
 
 [[redirects]]
     from = "/named/:color"
-    to = "/.netlify/functions/color"
+    to = "/.netlify/builders/color"
     status = 200
     force = true


### PR DESCRIPTION
Updating the invocation path from `/.netlify/functions/` to `/.netlify/builders/` to enable persistence.

This will address https://github.com/netlify/docs/issues/1548#issuecomment-992510675 

Test plan:

- [ ] Ensure the examples highlighted on the site still work as expected

   - https://deploy-preview-4--every-color.netlify.app/named/tomato
   - https://deploy-preview-4--every-color.netlify.app/hex/bada55
   - https://deploy-preview-4--every-color.netlify.app/rgb/80/90/100

- [ ] Check that I didn't miss any instances of `/.netlify/functions/` that should be updated